### PR TITLE
Add riscv64 Linux support

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,6 +16,9 @@ The binaries in release pages will work on the following platforms:
   * arm64 AmazonLinux 2, 2023
   * arm64 Ubuntu 18.04+
   * arm64 Debian 10+
+* perl-linux-riscv64.tar.{xz,gz}
+  * riscv64 Ubuntu 24.04+
+  * riscv64 Debian 13+
 
 # Note
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04 AS static-libcrypt
+ARG BASE_IMAGE=ubuntu:18.04
+FROM ${BASE_IMAGE} AS static-libcrypt
 
 RUN --mount=type=bind,target=/src set -eux; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -29,7 +30,7 @@ RUN --mount=type=bind,target=/src set -eux; \
   :
 
 # XXX We use ubuntu:18.04 because its gcc is configured with --enable-default-pie
-FROM ubuntu:18.04 AS builder
+FROM ${BASE_IMAGE} AS builder
 
 RUN --mount=type=bind,target=/src set -eux; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -55,7 +56,16 @@ RUN mkdir -p \
     /usr/local/lib \
     /usr/local/lib64 \
     ;
-RUN wget -q -O - https://raw.githubusercontent.com/skaji/relocatable-perl/main/perl-install | bash -s /perl
+RUN set -eux; \
+  if wget -q -O /tmp/perl-install https://raw.githubusercontent.com/skaji/relocatable-perl/main/perl-install && bash /tmp/perl-install /perl; then \
+    echo "Bootstrap: using pre-built relocatable-perl"; \
+  else \
+    echo "Bootstrap: no pre-built perl for $(uname -m), using system perl"; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update && apt-get install -y --no-install-recommends perl; \
+    mkdir -p /perl/bin; \
+    ln -sf /usr/bin/perl /perl/bin/perl; \
+  fi
 RUN wget -q -O /cpm https://raw.githubusercontent.com/skaji/cpm/main/cpm
 RUN --mount=type=bind,target=/src /perl/bin/perl /cpm install -g --cpmfile /src/build/cpm.yml
 
@@ -71,7 +81,7 @@ RUN /opt/perl/bin/perl /cpm install -g App::cpanminus App::ChangeShebang
 RUN /opt/perl/bin/change-shebang -f /opt/perl/bin/*
 RUN set -eux; \
   cd /tmp; \
-  _ARCHNAME=$(if [ $(uname -m) = x86_64 ]; then echo amd64; else echo arm64; fi); \
+  _ARCHNAME=$(if [ $(uname -m) = x86_64 ]; then echo amd64; elif [ $(uname -m) = riscv64 ]; then echo riscv64; else echo arm64; fi); \
   cp -r /opt/perl perl-linux-$_ARCHNAME; \
   tar cf perl-linux-$_ARCHNAME.tar perl-linux-$_ARCHNAME; \
   gzip -9 --stdout perl-linux-$_ARCHNAME.tar > /perl-linux-$_ARCHNAME.tar.gz; \

--- a/build/releases.pl
+++ b/build/releases.pl
@@ -49,7 +49,7 @@ if ($body->{errors}) {
     die $JSON->encode($body->{errors});
 }
 
-my $new_form = qr{/(?<version>\d+\.\d+\.\d+\.\d+)/perl-(?<os>linux|darwin)-(?<arch>amd64|arm64)\.tar\.(?<compress>gz|xz)$};
+my $new_form = qr{/(?<version>\d+\.\d+\.\d+\.\d+)/perl-(?<os>linux|darwin)-(?<arch>amd64|arm64|riscv64)\.tar\.(?<compress>gz|xz)$};
 my $old_form = qr{/(?<version>\d+\.\d+\.\d+\.\d+)/perl-(?:(?<arch>x86_64|aarch64)-)?(?<os>linux|darwin).*\.(?<compress>gz|xz)$};
 
 my @release;
@@ -71,7 +71,7 @@ for my $asset (map { $_->{node}{releaseAssets}{edges}->@* } $body->{data}{reposi
 
 my $sort_by = sub ($a, $b) {
     my %os = (linux => 1, darwin => 0);
-    my %arch = (amd64 => 1, arm64 => 0);
+    my %arch = (amd64 => 2, arm64 => 1, riscv64 => 0);
     my %compress = (xz => 1, gz => 0);
     $b->{version} cmp $a->{version}
     ||

--- a/perl-install
+++ b/perl-install
@@ -26,6 +26,7 @@ fi
 if [[ $_ARCH = aarch64 ]]; then
   _ARCH=arm64
 fi
+# riscv64 uname -m matches the release name, no mapping needed
 
 TAR_CMD=gtar
 if ! type $TAR_CMD &>/dev/null; then


### PR DESCRIPTION
## Summary

- Make Dockerfile base image configurable via `BASE_IMAGE` build arg (defaults to `ubuntu:18.04`, backward compatible)
- Add bootstrap fallback to system perl for architectures without a pre-built relocatable-perl (e.g. riscv64)
- Add riscv64 to output tarball arch name mapping, platform support docs, and release metadata

## Testing

Successfully built and tested on a native riscv64 host (Ubuntu 24.04):
```
$ docker build --build-arg BASE_IMAGE=ubuntu:24.04 -o linux-riscv64 -f build/Dockerfile .
$ perl-linux-riscv64/bin/perl -v
This is perl 5, version 42, subversion 2 (v5.42.2) built for riscv64-linux
```

## Notes

- CI workflow changes for riscv64 are intentionally **not** included since GitHub Actions doesn't offer riscv64 hosted runners. The riscv64 tarball can be built locally or via a self-hosted runner.
- The `BASE_IMAGE` arg and bootstrap fallback are generic and could help other new architectures in the future.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)